### PR TITLE
Update [TodayPic].js

### DIFF
--- a/client/src/components/todays-pic/[TodayPic].js
+++ b/client/src/components/todays-pic/[TodayPic].js
@@ -9,74 +9,81 @@ import {
   NextLink,
   Link,
   SimpleGrid,
+  Show,
 } from "@chakra-ui/react";
 import { ArrowForwardIcon } from "@chakra-ui/icons";
 
-function TodayPic() {
+const cardPics = [
+    {
+        src: '../fruit.png',
+        alt: 'Eventbrite display',
+        borderRadius: 'lg',
+    },
+    {
+        src: '../turtle.png',
+        alt: 'Turtle',
+        borderRadius: 'lg',
+    },
+    {
+        src: '../shutdown.png',
+        alt: 'Shutdown',
+        borderRadius: 'lg',
+    },
+    {
+        src: '../fruit.png',
+        alt: 'Eventbrite display',
+        borderRadius: 'lg',
+    },
+];
+
+function ShowCard() {
+
+    return cardPics.map((card, index) => (
+      <Card
+            key={index}
+            variant='outline'
+            maxW={{
+                base: '350px',
+            }}
+            spacing='3'
+        >
+            <CardBody>
+                <Image
+                    src={card.src}
+                />
+            </CardBody>
+        </Card>
+    ));
+}
+
+export default function TodayPic() {
   return (
-   <>
-      <SimpleGrid
-        templateColumns="repeat(auto-fill, minmax(600px, 1fr))"
-        ml={{ base: "20", sm: "10", md: "3", lg: "20" }}
-        mt={{ base: "10", md: "10" }}
-        align="center"
-        spacing="40px"
-      >
-        <Card
-          variant="outline"
-          maxW={{
-            base: "500px",
-          }}
-          spacing="3"
-        >
-          <CardBody>
-            <Image
-              src="../fruit.png"
-              alt="Eventbrite display"
-              borderRadius="lg"
-            />
-          </CardBody>
-        </Card>
+      <>
+          <SimpleGrid
+              templateColumns='repeat(auto-fill, minmax(400px, 1fr))'
+              ml={{ base: '20', sm: '10', md: '3', lg: '20' }}
+              mt={{ base: '10', md: '10' }}
+              align='center'
+              spacing={2}
+          >
 
-        {/* Second Card */}
-        <Card
-          variant="outline"
-          maxW={{
-            base: "500px",
-          }}
-          spacing="3"
-        >
-          <CardBody>
-            <Image src="../turtle.png" alt="Turtle" borderRadius="lg" />
-          </CardBody>
-        </Card>
+          <ShowCard />
+          </SimpleGrid>
 
-        {/* Third Card */}
-        <Card
-          variant="outline"
-          maxW={{
-            base: "500px",
-          }}
-          spacing="3"
-        >
-          <CardBody>
-            <Image src="../shutdown.png" alt="Shutdown" borderRadius="lg" />
-          </CardBody>
-        </Card>
-      </SimpleGrid>
-
-      {/* Arrow to see more events */}
-      <Flex mt={5} mb={5}>
-        <Spacer />
-        <Link href="/allHumour/humour" as={NextLink}>
-          <Heading as="h2" size="lg" mr="100">
-            more laughs
-            <ArrowForwardIcon boxSize={8} ml="5" />
-          </Heading>
-        </Link>
-      </Flex>
+          {/* Arrow to see more events */}
+          <Flex mt={5} mb={5}>
+              <Spacer />
+              <Link
+                  href='/allHumour/humour'
+                  as={NextLink}
+                  style={{ textDecoration: 'none' }}
+              >
+                  <Heading as='h2' size='md' mr='100'>
+                      more laughs
+                      <ArrowForwardIcon boxSize={8} ml='5' />
+                  </Heading>
+              </Link>
+          </Flex>
       </>
   );
 }
-
-export default TodayPic;


### PR DESCRIPTION
Fixed issues:

Modify the grid layout to display images side by side. The exact number of images per row should be responsive, depending on the size of the screen. This might be 2-3 pictures in a row for larger screens.

Adjust the sizes of the images so they fit neatly within the grid. The images should scale responsively with the size of the grid cells.

Standardize the size of the arrow icon and the font size of "more laughs" text at the bottom of the component. They should match the sizes used in other components.